### PR TITLE
Add support for changing fileDirectory

### DIFF
--- a/src/nodes/text-to-speech.html
+++ b/src/nodes/text-to-speech.html
@@ -250,8 +250,8 @@
 	<h3>Input message</h3>
 	<dl class="message-properties">
 
-		<dt class="optional">textToSynthesize <span class="property-type">string</span> </dt>
-		<dd> The text which should by synthesized. Can be enhanced with additional infos, 
+		<dt class="optional">text <span class="property-type">string</span> </dt>
+		<dd> The text which should be synthesized. Can be enhanced with additional infos, 
 			 like adding short breaks within your text <code>&lt;break time="600ms"/&gt;</code>. 
 			 See <a href="https://speech.microsoft.com/audiocontentcreation" target=_blank>here</a> for more.</dd>
 
@@ -281,6 +281,9 @@
 		<dt class="optional">storeAndReuse <span class="property-type">boolean</span> </dt>
 		<dd> If true, on each request the node checks wether the same request (regarding, text, voice, rate, pitch, ...) has 
 			 already been downloaded and reuses the file if so. </dd>
+
+		<dt class="optional">fileDirectory <span class="property-type">string</span> </dt>
+		<dd> Absolute path to store resultant wav file (including trailing "/").  Default is /data/ms-cognitive-services-audiofiles/ </dd>
 	</dl>
 	
 	<h3>Output message</h3>

--- a/src/nodes/text-to-speech.js
+++ b/src/nodes/text-to-speech.js
@@ -35,6 +35,7 @@ module.exports = function(RED) {
 				var rate 				= config.rate;
 				var pitch 				= config.pitch;
 				var storeAndReuse 		= config.storeAndReuse;
+				var fileDirectory	= "/data/ms-cognitive-services-audiofiles/";
 				
 				if (msg.payload !== undefined && msg.payload !== null) 
 				{
@@ -44,6 +45,7 @@ module.exports = function(RED) {
 					if (msg.payload.rate 			!== undefined) { rate = msg.payload.rate; }
 					if (msg.payload.pitch 			!== undefined) { pitch = msg.payload.pitch; }
 					if (msg.payload.storeAndReuse 	!== undefined) { storeAndReuse = msg.payload.storeAndReuse; }
+					if (msg.payload.fileDirectory	!== undefined) { fileDirectory = msg.payload.fileDirectory; }
 				}
 
 				var ssml = '';
@@ -64,7 +66,6 @@ module.exports = function(RED) {
 				}
 							 
 				const filename = md5(ssml) + ".wav";
-				const fileDirectory = "/data/ms-cognitive-services-audiofiles/";
 				const filepath = fileDirectory + filename;
 
 				if (!fs.existsSync(fileDirectory)){

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-ms-cognitive-services",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Node Red module for making use of Microsoft Cognitive Services, including Text-To-Speech.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This pull request makes a couple of corrections to the help text (one is just a typo, the other is that the message property is `msg.payload.text`, not `msg.payload.textToSynthesize`).

In addition, the primary reason for the change is to add the ability to set the output directory for the `wav` file as part of the message payload.  Having it hard-coded to `/data/ms-cognitive-services-audiofiles/` is problematic for me as I'm using this behind Home Assistant and it has its own built-in web server with a separate, internal path.  I'm passing the resultant `wav` file to a Raspberry Pi running `mpd` and I have to pass it a URL.  Providing the ability to pass the path as one of the message values (`msg.payload.fileDirectory`) provides a great deal more flexibility in the usability of this node.

The changes I've made were extremely basic and included an update to the help text.  I didn't see it as useful to adjust the node's form to allow the user to change the directory there, so that was not changed.